### PR TITLE
add queue scraper function in order to prevent function timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-# Indigent Defense Azure Scraper
+# Indigent Defense Data Scraper on Azure
 
 ## Development Environment Prerequisites
 - Python 3.8 with pip
 - Azure Function Core Tools 4
 - Contact an Open Austin dev to get Azure credentials, and values for required environment variables, which go in `local.settings.json`
+
 ## Steps to run an Azure function locally
 ### Http trigger function ("http-scraper")
 - To run the azure function app server locally, `cd` to the function app project root level (same as this README) and run this: `func start` (add `--verbose` if you like)  
@@ -23,6 +24,15 @@ Be sure to put `judicial_officers` in [] even if you only have one. The `test` a
     "test": true
 }
 ```
+
+### Message queue trigger function ("message-queue-scraper")
+Azure functions time out after 5-10 min. (exact timeout is configured in `host.json`) For this reason, when the http-scraper function hits a day that has a lot of cases, it will write to a message queue instead of scraping them, thus passing the work to this second function and avoiding a timeout. 
+
+Note that if you are working with this function, you may want to manually clear the message queue in between test runs, because it will attempt to process old messages left over from previous runs. It will try to process a message 5 times before moving it to the poison queue.
+
+### Blob trigger function ("blob-parser")
+
+Note that this function produces a lot of output after starting the function app, because it is continuously checking for its trigger. For this reason, you may want to disable this function during local development if it's not needed. To do this, click the 'A' in VS Code sidebar, find the function at the bottom under Workspace > Local Project > Functions, right-click on it and click Disable. You can use the same menu to re-enable it when you need it again.
 
 ### Deployment
 

--- a/host.json
+++ b/host.json
@@ -16,5 +16,15 @@
     "dynamicConcurrencyEnabled": true,
     "snapshotPersistenceEnabled": true
   },
-  "functionTimeout": "00:10:00"
+  "functionTimeout": "00:10:00",
+  "extensions": {
+    "queues": {
+        "maxPollingInterval": "00:00:02",
+        "visibilityTimeout" : "00:00:30",
+        "batchSize": 16,
+        "maxDequeueCount": 5,
+        "newBatchThreshold": 8,
+        "messageEncoding": "base64"
+    }
+  }
 }

--- a/http-scraper/function.json
+++ b/http-scraper/function.json
@@ -15,6 +15,13 @@
       "type": "http",
       "direction": "out",
       "name": "$return"
+    },
+    {
+      "type": "queue",
+      "direction": "out",
+      "name": "msg",
+      "queueName": "cases-to-scrape",
+      "connection": "AzureWebJobsStorage"
     }
   ]
 }

--- a/message-queue-scraper/__init__.py
+++ b/message-queue-scraper/__init__.py
@@ -1,0 +1,108 @@
+import logging, os, csv, urllib.parse, json
+from typing import List, Optional
+from datetime import datetime, timedelta, date
+from time import time
+
+from requests import *
+from bs4 import BeautifulSoup
+import azure.functions as func
+
+from azure.storage.blob import BlobServiceClient, ContainerClient
+from azure.identity import DefaultAzureCredential
+
+from shared.helpers import *
+
+
+def main(msg: func.QueueMessage) -> None:
+    queue_message = msg.get_body().decode('utf-8')
+    logging.info('Python queue trigger function processed a queue item: %s',
+                 queue_message)
+
+    # deserialize json message
+    # message has this form: { "case-urls": [str, str], "scrape-params": {"search-url": str, "base-url": str, .... } }
+    message_dict = json.loads(queue_message)
+    case_urls = message_dict["case-urls"]
+    base_url = message_dict["scrape-params"]["base-url"]
+    county = message_dict["scrape-params"]["county"]
+    odyssey_version = message_dict["scrape-params"]["odyssey-version"]
+    search_url = message_dict["scrape-params"]["search-url"]
+    notes = message_dict["scrape-params"]["notes"]
+    date_string = message_dict["scrape-params"]["date-string"]
+    date_string_underscore = date_string.replace("/", "_")
+    JO_id = message_dict["scrape-params"]["JO-id"]
+    # is this always going to work?
+    hidden_values = message_dict["scrape-params"]["hidden-values"]
+    # # TODO - get these from message
+    # ms_wait = 200
+    # location = None
+    ms_wait = message_dict["scrape-params"]["ms-wait"]
+    location = message_dict["scrape-params"]["location"]
+    court_calendar_link_text = "Court Calendar"
+
+    # initialize session
+    session = requests.Session()
+    # allow bad ssl and turn off warnings
+    session.verify = False
+    requests.packages.urllib3.disable_warnings(
+        requests.packages.urllib3.exceptions.InsecureRequestWarning
+    )
+
+    # initialize blob container client for sending html files to
+    blob_connection_str = os.getenv("AzureWebJobsStorage")
+    container_name_html = os.getenv("blob_container_name_html")
+    blob_service_client: BlobServiceClient = BlobServiceClient.from_connection_string(
+        blob_connection_str
+    )
+    container_client = blob_service_client.get_container_client(container_name_html)
+
+    # The following 2 searches' results are not actually used in this function -- only here because 
+    # this search is a necessary preliminary step to get the case URLs to load.
+    # hit the search page to gather initial data
+    search_page_html = request_page_with_retry(
+        session=session,
+        url=search_url
+        if odyssey_version < 2017
+        else urllib.parse.urljoin(base_url, "Home/Dashboard/26"),
+        verification_text="Court Calendar"
+        if odyssey_version < 2017
+        else "SearchCriteria.SelectedCourt",
+        http_method=HTTPMethod.GET,
+        ms_wait=ms_wait,
+    )
+
+    # POST a request for search results
+    results_page_html = request_page_with_retry(
+        session=session,
+        url=search_url
+        if odyssey_version < 2017
+        else urllib.parse.urljoin(
+            base_url, "Hearing/SearchHearings/HearingSearch"
+        ),
+        verification_text="Record Count"
+        if odyssey_version < 2017
+        else "Search Results",
+        data=create_search_form_data(
+            date_string, JO_id, hidden_values, odyssey_version
+        ),
+        ms_wait=ms_wait,
+    )
+
+    # actual scraping of case urls passed in message
+    for case_url in case_urls:
+        case_id = case_url.split("=")[1]
+        logging.info(f"{case_id} - scraping case")
+        # make request for the case
+        case_html = request_page_with_retry(
+            session=session,
+            url=case_url,
+            verification_text="Date Filed"
+        )
+
+        # write html case data
+        logging.info(f"{len(case_html)} response string length")
+        file_hash_dict = hash_case_html(case_html)
+        blob_name = f"{file_hash_dict['case_no']}:{county}:{date_string_underscore}:{file_hash_dict['file_hash']}.html"
+        logging.info(f"Sending {blob_name} to {container_name_html} container...")
+        write_string_to_blob(file_contents=case_html, blob_name=blob_name, container_client=container_client, container_name=container_name_html)
+
+    logging.info(f"Successfully scraped batch of cases for {JO_id} -- {date_string}")

--- a/message-queue-scraper/function.json
+++ b/message-queue-scraper/function.json
@@ -1,0 +1,12 @@
+{
+  "scriptFile": "__init__.py",
+  "bindings": [
+    {
+      "name": "msg",
+      "type": "queueTrigger",
+      "direction": "in",
+      "queueName": "cases-to-scrape",
+      "connection": "AzureWebJobsStorage"
+    }
+  ]
+}

--- a/message-queue-scraper/readme.md
+++ b/message-queue-scraper/readme.md
@@ -1,0 +1,11 @@
+# QueueTrigger - Python
+
+The `QueueTrigger` makes it incredibly easy to react to new Queues inside of Azure Queue Storage. This sample demonstrates a simple use case of processing data from a given Queue.
+
+## How it works
+
+For a `QueueTrigger` to work, you provide a path which dictates where the queue messages are located inside your container.
+
+## Learn more
+
+<TODO> Documentation

--- a/message-queue-scraper/sample.dat
+++ b/message-queue-scraper/sample.dat
@@ -1,0 +1,1 @@
+sample queue data

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 # The Python Worker is managed by the Azure Functions platform
 # Manually managing azure-functions-worker may cause unexpected issues
 
+azure-cosmos
 azure-functions==1.12.0
 azure-identity
 azure-storage-blob==12.14.1

--- a/shared/helpers.py
+++ b/shared/helpers.py
@@ -1,6 +1,7 @@
 import os, sys
 import requests
 from time import sleep
+from datetime import date
 import logging
 from typing import Dict, Optional, Tuple, Literal
 from enum import Enum
@@ -102,6 +103,25 @@ def request_page_with_retry(
                 page_text=response.text,
             )
     return response.text
+
+def create_single_case_search_form_data(hidden_values: Dict[str, str], case_number: str):
+    form_data = {}
+    form_data.update(hidden_values)
+    os_specific_time_format = "%#m/%#d/%Y" if os.name == 'nt' else "%-m/%-d/%Y"
+    form_data.update(
+        {
+            "__EVENTTARGET":"",
+            "SearchBy": "0",
+            "DateSettingOnAfter": "1/1/1970",
+            "DateSettingOnBefore": date.today().strftime(os_specific_time_format),
+            "SearchType": "CASE",  # Search by case id
+            "SearchMode": "CASENUMBER",
+            "CourtCaseSearchValue": case_number,
+            "CaseCategories": "",
+            "cboJudOffc":"38501",
+        }
+    )
+    return form_data
 
 def write_string_to_blob(
     file_contents: str, blob_name: str, container_client, container_name: str, overwrite: bool = False


### PR DESCRIPTION
This adds a second scraping function `message-queue-scraper` that is triggered by a new message on the queue `cases-to-scrape`. This second scraping function is necessary due to the 10 minute limit on Azure functions -- previously, when the first function `http-scraper` hit a day that contained 100 cases, it would time out. Now, that first function `http-scraper` passes off the scraping work to the second function `message-queue-scraper` when it hits a large number of cases.

Changes in this PR:

* The logic in `http-scraper`: for each day, if there are 10 or less cases, just scrape as usual. If there are more than 10 cases, write a message to the queue containing all the info needed to scrape those cases. Each message contains 1 batch of case URLs, with the batch size set in configuration. (Be sure to add `"cases_batch_size":50` to your `local.settings.json`)
* `message-queue-scraper` does contain 2 search requests prior to actually scraping the list of case URLs, because Odyssey requires a new session to do that.
* `http-scraper/__init__.py` is now just 1 function. (eg the `scrape` function has been merged into the main function.) This was necessary in order to keep the message queue output binding in scope. Also, because of this merging into 1 function, the loop `for date in <date-range>` had to change to `for day in <date-range>` to avoid naming conflict with Python's native datetime lib.
* Added `azure-cosmos` to `requirements-txt` -- necessary for `blob-parser` to write to Cosmos DB
