### PR TITLE
Host config & add session caching, client caching

### DIFF
--- a/blob-parser/__init__.py
+++ b/blob-parser/__init__.py
@@ -24,13 +24,13 @@ def main(myblob: func.InputStream):
 
     # Get case info from file name, which looks like: case-html/15-1367CR-3:hays:12_13_2022:96316e53a9b706e0.html
     # First strip off case-html/ from beginning and .html from end of blob name
-    stripped_name = myblob.name.strip("case-html/.")
+    stripped_name = myblob.name.replace("case-html/", "").replace(".html", "")
     # Then split by : as delimiter
     file_info = stripped_name.split(":")
     case_num = file_info[0]
     county = file_info[1]
     case_date = file_info[2]
-    html_file_hash = file_info[3][:-5]
+    html_file_hash = file_info[3]
     logging.info(
         f"Retrieved the following metadata: \n"
         f"Case Date: {case_num}\n"

--- a/host.json
+++ b/host.json
@@ -13,17 +13,17 @@
     "version": "[3.*, 4.0.0)"
   },
   "concurrency": {
-    "dynamicConcurrencyEnabled": true,
-    "snapshotPersistenceEnabled": true
+    "dynamicConcurrencyEnabled": false,
+    "snapshotPersistenceEnabled": false
   },
   "functionTimeout": "00:10:00",
   "extensions": {
     "queues": {
-        "maxPollingInterval": "00:00:02",
+        "maxPollingInterval": "00:00:30",
         "visibilityTimeout" : "00:00:30",
-        "batchSize": 16,
+        "batchSize": 8,
         "maxDequeueCount": 5,
-        "newBatchThreshold": 8,
+        "newBatchThreshold": 2,
         "messageEncoding": "base64"
     }
   }

--- a/shared/helpers.py
+++ b/shared/helpers.py
@@ -8,6 +8,37 @@ from enum import Enum
 import xxhash
 from bs4 import BeautifulSoup
 from azure.storage.blob import BlobServiceClient
+from azure.cosmos import CosmosClient
+
+
+def initialize_session():
+    # initialize session
+    session = requests.Session()
+    # allow bad ssl and turn off warnings
+    session.verify = False
+    requests.packages.urllib3.disable_warnings(
+        requests.packages.urllib3.exceptions.InsecureRequestWarning
+    )
+    return session
+
+
+def initialize_blob_container_client(container_name):
+    blob_connection_str = os.getenv("AzureWebJobsStorage")
+    blob_service_client: BlobServiceClient = BlobServiceClient.from_connection_string(
+        blob_connection_str
+    )
+    container_client = blob_service_client.get_container_client(container_name)
+    return container_client
+
+
+def initialize_cosmos_db_client(container_name):
+    cosmos_connection_str = os.getenv("AzureCosmosStorage")
+    cosmos_service_client: CosmosClient = CosmosClient.from_connection_string(
+        cosmos_connection_str
+    )
+    cosmos_db_client = cosmos_service_client.get_database_client("cases-json-db")
+    container_client = cosmos_db_client.get_container_client(container_name)
+    return container_client
 
 
 def write_debug_and_quit(


### PR DESCRIPTION
This fixes some performance issues, that were necessary in order to run the "big" (5 year) scrape job.

1 - Session and client caching : Check if host already initialized a session, container client, or cosmos db client, and use it if already exists.

2 - host.json changes : Turned off dynamic scaling, which also means that it actually uses the batchSize newBatchThreshold settings, which have been turned way down to avoid overheating our little Consumption Plan hosts.

Big shout to to @normaljosh for also finding and adding a bugfix in the blob parser, which was stripping out ANY characters from the file name that matched "html", not just the start or end "html" as previously intended!