### PR TITLE
patch to handle also known as, and cases without gender

### DIFF
--- a/shared/pre2017.py
+++ b/shared/pre2017.py
@@ -63,6 +63,23 @@ def parse(case_soup: BeautifulSoup, case_num: str) -> Dict:
                     break
             state_rows = state_rows[::-1]
             defendant_rows = defendant_rows[::-1]
+            # Get the position of the item containing gender
+            gender_position = 0
+            for i, row in enumerate(defendant_rows[0]):
+                if row[:5] == "Male " or row[:7] == "Female ":
+                    gender_position = i
+                if row[:5] == ["DOB: "]:
+                    dob_position = i
+            # Handle "Also Known as" which will mess with positions
+            if gender_position > 2:
+                full_name = " ".join(defendant_rows[0][1:gender_position])
+                defendant_rows[0] = (
+                    [defendant_rows[0][0]]
+                    + [full_name]
+                    + defendant_rows[0][gender_position:]
+                )
+            if gender_position == 0:
+                defendant_rows[0].insert(2, "Unavailable Unavailable")
             bondsman_rows = bondsman_rows[::-1]
             if bondsman_rows[0][0] != "Bondsman":
                 bondsman_rows = []
@@ -75,7 +92,7 @@ def parse(case_soup: BeautifulSoup, case_num: str) -> Dict:
                 "sex": defendant_rows[0][2].split()[0],
                 "race": " ".join(defendant_rows[0][2].split()[1:])
                 if len(defendant_rows[0]) > 3
-                else "",
+                else "Unavailable",
                 "date of birth": defendant_rows[0][3].split()[1]
                 if len(defendant_rows[0]) > 3 and len(defendant_rows[0][3].split()) > 1
                 else "",


### PR DESCRIPTION
This whole parser should really get a rewrite at some point, but this is a quick patch to handle cases where there's an Also Known As in the name, or no race and gender section, as these were previously incorrect. 

Also changed the null value for race to "Unavailable", since this seems to be what odyssey uses. 