### PR TITLE
Add terraform management of infrastructure, separate storage account for html and queue

### DIFF
--- a/.funcignore
+++ b/.funcignore
@@ -1,1 +1,2 @@
 .venv
+terraform/

--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ Note that this function produces a lot of output after starting the function app
 
 ### Deployment
 
-- Publish final app with the command `func azure functionapp publish indigent-defense-stats`. It's a good idea to verify code both locally and deployed before merging.
+- Publish to Azure with the command `func azure functionapp publish indigent-defense-stats-dev-function-app`. (You need to be logged in to Azure CLI.) That's our dev environment, so deploy there as much as you like; it's meant to be played with and broken. When you run the function app locally, it will still be talking to blob containers, a message queue, and a Cosmos DB on Azure, so 95% of the time local testing should be fine. However, it's a good idea to at least verify final code on Azure before opening a pull request. Changes merged into main will then be published on the prod environment.

--- a/blob-parser/function.json
+++ b/blob-parser/function.json
@@ -6,7 +6,7 @@
       "type": "blobTrigger",
       "direction": "in",
       "path": "case-html/{name}",
-      "connection": "AzureWebJobsStorage"
+      "connection": "ScrapeDataStorage"
     }
   ]
 }

--- a/http-scraper/function.json
+++ b/http-scraper/function.json
@@ -21,7 +21,7 @@
       "direction": "out",
       "name": "msg",
       "queueName": "cases-to-scrape",
-      "connection": "AzureWebJobsStorage"
+      "connection": "ScrapeDataStorage"
     }
   ]
 }

--- a/message-queue-scraper/function.json
+++ b/message-queue-scraper/function.json
@@ -6,7 +6,7 @@
       "type": "queueTrigger",
       "direction": "in",
       "queueName": "cases-to-scrape",
-      "connection": "AzureWebJobsStorage"
+      "connection": "ScrapeDataStorage"
     }
   ]
 }

--- a/shared/helpers.py
+++ b/shared/helpers.py
@@ -23,7 +23,7 @@ def initialize_session():
 
 
 def initialize_blob_container_client(container_name):
-    blob_connection_str = os.getenv("AzureWebJobsStorage")
+    blob_connection_str = os.getenv("ScrapeDataStorage")
     blob_service_client: BlobServiceClient = BlobServiceClient.from_connection_string(
         blob_connection_str
     )

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,41 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version = "3.43.0"
+  hashes = [
+    "h1:zf15PjCXucKHP9MhpB1EgXKqqUWh/NJf7Hf1PoQChUE=",
+    "zh:1a6d3553a8b9c85193d8334e8678aae305d14ec1d69b0d45799c322145d41475",
+    "zh:1cb9ecd6531060c8f52d4f70863754ef18d3c297dee2aa173ce6dbd6f3c62621",
+    "zh:21effe14cf1f5bace7aa172198ee2aa6ffc78324e4648af9b8df8b29995fa711",
+    "zh:29e53d13567d1497388c4264fea7548a45a3d1065129a475f0c8708eb0b9fa4d",
+    "zh:6c9036ed1371220709fab11ecd790953bb066bc8113707d3f4b9334d07fddf11",
+    "zh:7f26877a5216fb92e2a1594da7eb61058a984e7f8b305c45745ad181c0357b71",
+    "zh:a080ea3a591b353dd3432d5f1a7fe717dc733a02429b50ff38ef0fba92bd93e2",
+    "zh:b880602640876fbccf7d2d6dbbf6a076bf42126e07990975a29995c1a899563b",
+    "zh:c46125c6fcf67f69b8d33f29e5362ae78fc305787be77076c10f36561c2076d2",
+    "zh:f08642f55085ac03bfad32917abd42b75f2dffb7b9d8e7c310cc230f9a15e756",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f85af4d3af54ebad40ea6cf4dfd5cb1f7b0666cf4793711a1bff719f059177f7",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.4.3"
+  constraints = ">= 3.1.0"
+  hashes = [
+    "h1:tL3katm68lX+4lAncjQA9AXL4GR/VM+RPwqYf4D2X8Q=",
+    "zh:41c53ba47085d8261590990f8633c8906696fa0a3c4b384ff6a7ecbf84339752",
+    "zh:59d98081c4475f2ad77d881c4412c5129c56214892f490adf11c7e7a5a47de9b",
+    "zh:686ad1ee40b812b9e016317e7f34c0d63ef837e084dea4a1f578f64a6314ad53",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:84103eae7251384c0d995f5a257c72b0096605048f757b749b7b62107a5dccb3",
+    "zh:8ee974b110adb78c7cd18aae82b2729e5124d8f115d484215fd5199451053de5",
+    "zh:9dd4561e3c847e45de603f17fa0c01ae14cae8c4b7b4e6423c9ef3904b308dda",
+    "zh:bb07bb3c2c0296beba0beec629ebc6474c70732387477a65966483b5efabdbc6",
+    "zh:e891339e96c9e5a888727b45b2e1bb3fcbdfe0fd7c5b4396e4695459b38c8cb1",
+    "zh:ea4739860c24dfeaac6c100b2a2e357106a89d18751f7693f3c31ecf6a996f8d",
+    "zh:f0c76ac303fd0ab59146c39bc121c5d7d86f878e9a69294e29444d4c653786f8",
+    "zh:f143a9a5af42b38fed328a161279906759ff39ac428ebcfe55606e05e1518b93",
+  ]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,176 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.43.0"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.1"
+    }
+  }
+
+  required_version = ">= 1.1.0"
+
+  # We are using a remote backend so our distributed team can share terraform state. 
+  # Need to pass in container name, key from command line when running terraform init.
+  # 1. Be logged in to Azure CLI
+  # 2. Set env variables:
+  #  export IDS_tfstate_container_name="terraform-state-dev"
+  #  export IDS_tfstate_file_name="dev.terraform.tfstate"
+  # 3. Run command:
+  #   terraform init \
+  #   -backend-config="container_name=$IDS_tfstate_container_name" \
+  #   -backend-config="key=$IDS_tfstate_file_name"
+  backend "azurerm" {
+    resource_group_name  = "rg-terraform-state"
+    storage_account_name = "terraformstatestorageids"
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "resource_group" {
+  name     = "${var.project}-${var.environment}-resource-group"
+  location = var.location
+}
+
+# Random string needed for storage account names since they need to be globally unique
+resource "random_string" "random" {
+  length  = 5
+  special = false
+  upper   = false
+}
+
+# Cosmos DB resources
+resource "azurerm_cosmosdb_account" "cosmos_acct" {
+  name                      = "${var.project}-${var.environment}-cosmos-acct"
+  location                  = azurerm_resource_group.resource_group.location
+  resource_group_name       = azurerm_resource_group.resource_group.name
+  offer_type                = "Standard"
+  kind                      = "GlobalDocumentDB"
+  enable_automatic_failover = var.environment == "prod" ? true : false
+  capabilities {
+    name = "EnableServerless"
+  }
+  geo_location {
+    location          = azurerm_resource_group.resource_group.location
+    failover_priority = 0
+  }
+  consistency_policy {
+    consistency_level       = "BoundedStaleness"
+    max_interval_in_seconds = 300
+    max_staleness_prefix    = 100000
+  }
+  depends_on = [
+    azurerm_resource_group.resource_group
+  ]
+}
+
+resource "azurerm_cosmosdb_sql_database" "cosmos_db" {
+  name                = "cases-json-db"
+  resource_group_name = azurerm_resource_group.resource_group.name
+  account_name        = azurerm_cosmosdb_account.cosmos_acct.name
+}
+
+resource "azurerm_cosmosdb_sql_container" "cosmos_json_container" {
+  name                  = "case-json"
+  resource_group_name   = azurerm_resource_group.resource_group.name
+  account_name          = azurerm_cosmosdb_account.cosmos_acct.name
+  database_name         = azurerm_cosmosdb_sql_database.cosmos_db.name
+  partition_key_path    = "/definition/id"
+  partition_key_version = 1
+}
+
+# Raw html, message queue resources
+# Azure docs recommend using separate storage accounts for function app backend vs.
+# for other resources that the function app interacts with
+resource "azurerm_storage_account" "scrape_data_storage_account" {
+  name                     = "${var.proj_prefix}${var.environment}data${random_string.random.result}"
+  resource_group_name      = azurerm_resource_group.resource_group.name
+  location                 = azurerm_resource_group.resource_group.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_container" "html_container" {
+  name                  = "case-html"
+  storage_account_name  = azurerm_storage_account.scrape_data_storage_account.name
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_queue" "cases_queue" {
+  name                 = "cases-to-scrape"
+  storage_account_name = azurerm_storage_account.scrape_data_storage_account.name
+}
+
+# Function app resources
+resource "azurerm_storage_account" "func_storage_account" {
+  name                     = "${var.proj_prefix}${var.environment}func${random_string.random.result}"
+  resource_group_name      = azurerm_resource_group.resource_group.name
+  location                 = azurerm_resource_group.resource_group.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_application_insights" "application_insights" {
+  name                = "${var.project}-${var.environment}-app-insights"
+  location            = azurerm_resource_group.resource_group.location
+  resource_group_name = azurerm_resource_group.resource_group.name
+  application_type    = "other"
+}
+
+resource "azurerm_service_plan" "app_service_plan" {
+  name                = "${var.project}-${var.environment}-app-service-plan"
+  location            = azurerm_resource_group.resource_group.location
+  resource_group_name = azurerm_resource_group.resource_group.name
+  os_type             = "Linux"
+  sku_name            = "Y1"
+}
+
+resource "azurerm_linux_function_app" "function_app" {
+  name                    = "${var.project}-${var.environment}-function-app"
+  resource_group_name     = azurerm_resource_group.resource_group.name
+  location                = azurerm_resource_group.resource_group.location
+  service_plan_id         = azurerm_service_plan.app_service_plan.id
+
+  builtin_logging_enabled = true
+  functions_extension_version = "~4"
+  # daily_memory_time_quota = 100000 # TODO - maybe conditionally add a quota for dev/test environments?
+
+  storage_account_name       = azurerm_storage_account.func_storage_account.name
+  storage_account_access_key = azurerm_storage_account.func_storage_account.primary_access_key
+
+  app_settings = {
+    "WEBSITE_RUN_FROM_PACKAGE" = "", # blank bc we are not deploying app changes with terraform
+    "ScrapeDataStorage" = azurerm_storage_account.scrape_data_storage_account.primary_connection_string,
+    "blob_container_name_html" = azurerm_storage_container.html_container.name,
+    "cases_batch_size" = 50,
+    "AzureCosmosStorage" = azurerm_cosmosdb_account.cosmos_acct.connection_strings[0],
+    "blob_container_name_json" = azurerm_cosmosdb_sql_container.cosmos_json_container.name
+  }
+
+  site_config {
+    application_insights_connection_string = azurerm_application_insights.application_insights.connection_string
+    application_insights_key               = azurerm_application_insights.application_insights.instrumentation_key
+    application_stack {
+      python_version = "3.9"
+    }
+  }
+
+  depends_on = [
+    azurerm_application_insights.application_insights,
+    azurerm_service_plan.app_service_plan,
+    azurerm_storage_account.scrape_data_storage_account,
+    azurerm_cosmosdb_account.cosmos_acct
+  ]
+
+  lifecycle {
+    ignore_changes = [
+      app_settings["WEBSITE_RUN_FROM_PACKAGE"], # bc we are not deploying app changes with terraform
+    ]
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,39 @@
+output "function_app_name" {
+  value       = azurerm_linux_function_app.function_app.name
+  description = "Deployed function app name"
+}
+
+output "function_app_default_hostname" {
+  value       = azurerm_linux_function_app.function_app.default_hostname
+  description = "Deployed function app hostname"
+}
+
+output "function_app_storage_acct_connection_str" {
+  value       = azurerm_storage_account.func_storage_account.primary_connection_string
+  description = "For local.settings.json - AzureWebJobsStorage"
+  sensitive   = true
+}
+
+output "function_app_insights_instrumentation_key" {
+  value       = azurerm_application_insights.application_insights.instrumentation_key
+  description = "For local.settings.json - APPINSIGHTS_INSTRUMENTATIONKEY"
+  sensitive   = true
+}
+
+output "function_app_insights_connection_str" {
+  value       = azurerm_application_insights.application_insights.connection_string
+  description = "For local.settings.json - APPLICATIONINSIGHTS_CONNECTION_STRING"
+  sensitive   = true
+}
+
+output "scrape_data_storage_acct_connection_str" {
+  value       = azurerm_storage_account.scrape_data_storage_account.primary_connection_string
+  description = "For local.settings.json - ScrapeDataStorage"
+  sensitive   = true
+}
+
+output "cosmosdb_connection_strings" {
+   value = azurerm_cosmosdb_account.cosmos_acct.connection_strings
+   description = "For local.settings.json - AzureCosmosStorage"
+   sensitive   = true
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,27 @@
+variable "project" {
+  type        = string
+  default     = "indigent-defense-stats"
+  description = "Project name"
+}
+
+variable "proj_prefix" {
+  type        = string
+  default     = "ids"
+  description = "Project name abbreviation for use as prefix in short fields"
+}
+
+variable "environment" {
+  type        = string
+  default     = "dev"
+  description = "Environment (dev / test / prod)"
+  validation {
+    condition     = var.environment == "dev" || var.environment == "test" || var.environment == "prod"
+    error_message = "Environment must be either dev, test, or prod"
+  }
+}
+
+variable "location" {
+  type        = string
+  default     = "South Central US"
+  description = "location location location"
+}


### PR DESCRIPTION
* Adds terraform infrastructure management, with multiple environments. `dev` to play with and test stuff on before deploying to `prod`, the "real" one.

* Infrastructure all remains the same except for 1 thing: when you make a function app, you have to link it to a storage account to use for its backend, and the Azure docs recommend using a different storage account for everything else the function app uses. Before, we were using the function app's main storage account (default name "AzureWebJobs" in function settings) for the html files and the message queue, as well. Now, this PR changes it to use a new, separate storage account for html files and queue. (named "ScrapeDataStorage" in function settings)

* Check slack or contact me for the new `local.settings.json`
New deployment command: `func azure functionapp publish indigent-defense-stats-dev-function-app`
Deploy to your heart's content now!