### PR TITLE
Add Docker configuration + instructions for developers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM  --platform=linux/amd64 python:3.8-slim-bullseye
+WORKDIR /app
+
+# Install Azure CLI and Azure Func Tools v4
+# https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux
+# https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local?tabs=v4
+RUN apt-get -y update
+RUN apt-get -y install ca-certificates curl apt-transport-https lsb-release gnupg
+
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -sLS https://packages.microsoft.com/keys/microsoft.asc \
+  | gpg --dearmor \
+  | tee /etc/apt/keyrings/microsoft.gpg > /dev/null
+RUN chmod go+r /etc/apt/keyrings/microsoft.gpg
+
+RUN echo "deb [arch=`dpkg --print-architecture` signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" \
+  | tee /etc/apt/sources.list.d/azure-cli.list
+RUN echo "deb [arch=`dpkg --print-architecture` signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/debian/$(lsb_release -rs | cut -d'.' -f 1)/prod $(lsb_release -cs) main" \
+  | tee /etc/apt/sources.list.d/dotnetdev.list
+
+RUN cat /etc/apt/sources.list.d/dotnetdev.list
+RUN apt-get -y update && apt-get -y install azure-cli azure-functions-core-tools-4
+
+# Install Python dependencies, then copy the rest of the project in
+RUN python -m pip install --upgrade pip
+COPY requirements.txt ./
+RUN pip install -r requirements.txt
+
+COPY . ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM  --platform=linux/amd64 python:3.8-slim-bullseye
+FROM  --platform=linux/amd64 python:3.9-slim-bullseye
 WORKDIR /app
 
 # Install Azure CLI and Azure Func Tools v4

--- a/README.md
+++ b/README.md
@@ -37,3 +37,29 @@ Note that this function produces a lot of output after starting the function app
 ### Deployment
 
 - Publish to Azure with the command `func azure functionapp publish indigent-defense-stats-dev-function-app`. (You need to be logged in to Azure CLI.) That's our dev environment, so deploy there as much as you like; it's meant to be played with and broken. When you run the function app locally, it will still be talking to blob containers, a message queue, and a Cosmos DB on Azure, so 95% of the time local testing should be fine. However, it's a good idea to at least verify final code on Azure before opening a pull request. Changes merged into main will then be published on the prod environment.
+
+## Devlopment via Docker
+
+Build and run the container with `docker-compose`
+
+```sh
+docker-compose up
+```
+
+This will mount the repository as a volume in the container, so you can continue
+to edit code as normal.
+
+### Notes for Macbook M1 Users
+
+The container runs using amd64 emulation due to Microsoft's lack of Linux
+aarch64 binaries for Azure Functions Tools. Emulation causes the container to
+run considerably slower than natively.
+
+In order for the emulation to work properly, you must meet the following requirements:
+
+- Docker version 4.16.0+
+- macOS 13+
+- Enable `Use rosetta for x86/amd64` in Settings > Features in Development
+
+If you see the error `Function not implemented`, this likely means you aren't
+configured properly for emulation.

--- a/README.md
+++ b/README.md
@@ -57,9 +57,17 @@ run considerably slower than natively.
 
 In order for the emulation to work properly, you must meet the following requirements:
 
-- Docker version 4.16.0+
 - macOS 13+
-- Enable `Use rosetta for x86/amd64` in Settings > Features in Development
+  - Rosetta 2 installed
+- Docker version 4.16.0+
+  - Enable `Use Virtualization framework` in Docker Destkop Settings > General
+  - Enable `Use rosetta for x86/amd64` in Docker Desktop Settings > Features in Development
 
 If you see the error `Function not implemented`, this likely means you aren't
-configured properly for emulation.
+configured properly for emulation. Ensure the following:
+
+- The above requirements are all met by your machine
+- Your macOS terminal is **not** being emulated when you build & run docker compose
+  - The `arch` command should print `arm64`
+- That you built the container image _after_ installing everything
+  - If you adjusted one of these configurations after building the image, try re-building with `docker-compose build --no-cache`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '2'
+services:
+  python:
+    build: .
+    command: sh -c "func start"
+    platform: linux/arm64
+    ports:
+      - 7071:7071
+    environment:
+      - DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
+    working_dir: /app
+    volumes:
+      - ./:/app


### PR DESCRIPTION
Closes #26.

### What This Does

* Adds a `Dockerfile` using the base python3.8 image, that then installs the necessary Azure CLI tools
* Adds a `docker-compose.yml` that manages configuration for running the docker image in development
* Updates README.md with instructions on how to use it

### Steps to Test

1. Make sure you Docker installed
    * If on an M1, please note the README instructions on specific configurations and versions
1. Run `docker-compose up`, confirm the service starts up OK